### PR TITLE
Add an auto-download script that supports 7B, 13B & 30B models

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,83 +15,23 @@ A chat interface based on `llama.cpp` for running Alpaca models. Entirely self-h
 Setting up Serge is very easy. TLDR for running it with Alpaca 7B:
 
 ```
-git clone git@github.com:nsarrazin/serge.git
-cd serge
+git clone git@github.com:nsarrazin/serge.git && cd serge
 
 cp .env.sample .env
 
 docker compose up -d
-docker compose exec api python3 /usr/src/app/utils/download.py tokenizer 7B 13B
+docker compose exec api python3 /usr/src/app/utils/download.py tokenizer 7B
 ```
 
-(You will need `huggingface_hub` for fetching the tokenizer, just run `pip install huggingface_hub` before if you don't have it, no setup needed. Otherwise just [download the file manually](https://huggingface.co/decapoda-research/llama-7b-hf/blob/main/tokenizer.model))
+(You can pass `7B 13B 30B` as an argument to download multiple models.)
 
 Then just go to http://localhost:8008/ and you're good to go!
 
-## Getting the weights
+## Models
 
-You will need to download the weights for the model you want to use. Currently we only support 7B and 13B models. Place the downloaded weights in the `api/weights` folder.
+Currently only the 7B, 13B and 30B alpaca models are supported. There's a download script for downloading them inside of the container, described above.
 
-### 7B (~4GB of ram)
-
-Recommmended way is from huggingface. One-liner:
-
-```
-python -c 'from huggingface_hub import hf_hub_download; hf_hub_download(repo_id="Pi3141/alpaca-7B-ggml", filename="ggml-model-q4_0.bin", local_dir=".", local_dir_use_symlinks=False)'
-mv ggml-model-q4_0.bin api/weights/ggml-alpaca-7b-q4.bin
-```
-
-Or you can download the file manually from [here](https://huggingface.co/Pi3141/alpaca-7B-ggml/resolve/main/ggml-model-q4_0.bin) and place it in the `api/weights` folder.
-
-Alternatives :
-
-```
-# torrent
-magnet:?xt=urn:btih:053b3d54d2e77ff020ebddf51dad681f2a651071&dn=ggml-alpaca-13b-q4.bin&tr=udp%3a%2f%2ftracker.opentrackr.org%3a1337%2fannounce&tr=udp%3a%2f%2fopentracker.i2p.rocks%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.openbittorrent.com%3a6969%2fannounce&tr=udp%3a%2f%2f9.rarbg.com%3a2810%2fannounce
-
-# or any of these should work
-curl -o ggml-alpaca-7b-q4.bin -C - https://gateway.estuary.tech/gw/ipfs/QmQ1bf2BTnYxq73MFJWu1B7bQ2UD6qG7D7YDCxhTndVkPC
-curl -o ggml-alpaca-7b-q4.bin -C - https://ipfs.io/ipfs/QmQ1bf2BTnYxq73MFJWu1B7bQ2UD6qG7D7YDCxhTndVkPC
-curl -o ggml-alpaca-7b-q4.bin -C - https://cloudflare-ipfs.com/ipfs/QmQ1bf2BTnYxq73MFJWu1B7bQ2UD6qG7D7YDCxhTndVkPC
-```
-
-### 13B (~10GB of ram)
-
-Recommmended way is from huggingface. One-liner:
-
-```
-python -c 'from huggingface_hub import hf_hub_download; hf_hub_download(repo_id="Pi3141/alpaca-13B-ggml", filename="ggml-model-q4_0.bin", local_dir=".", local_dir_use_symlinks=False)'
-mv ggml-model-q4_0.bin api/weights/ggml-alpaca-13b-q4.bin
-```
-
-Or you can download the file manually from [here](https://huggingface.co/Pi3141/alpaca-13B-ggml/resolve/main/ggml-model-q4_0.bin) and place it in the `api/weights` folder.
-
-Alternatives:
-
-```
-# torrent
-magnet:?xt=urn:btih:053b3d54d2e77ff020ebddf51dad681f2a651071&dn=ggml-alpaca-13b-q4.bin&tr=udp%3a%2f%2ftracker.opentrackr.org%3a1337%2fannounce&tr=udp%3a%2f%2fopentracker.i2p.rocks%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.openbittorrent.com%3a6969%2fannounce&tr=udp%3a%2f%2f9.rarbg.com%3a2810%2fannounce
-
-# or any of these should work
-curl -o ggml-alpaca-13b-q4.bin -C - https://gateway.estuary.tech/gw/ipfs/Qme6wyw9MzqbrUMpFNVq42rC1kSdko7MGT9CL7o1u9Cv9G
-curl -o ggml-alpaca-13b-q4.bin -C - https://ipfs.io/ipfs/Qme6wyw9MzqbrUMpFNVq42rC1kSdko7MGT9CL7o1u9Cv9G
-curl -o ggml-alpaca-13b-q4.bin -C - https://cloudflare-ipfs.com/ipfs/Qme6wyw9MzqbrUMpFNVq42rC1kSdko7MGT9CL7o1u9Cv9G
-```
-
-### 30B ~(30GB of ram)
-
-Recommmended way is from huggingface. One-liner:
-
-```
-python -c 'from huggingface_hub import hf_hub_download; hf_hub_download(repo_id="Pi3141/alpaca-30B-ggml", filename="ggml-model-q4_0.bin", local_dir=".", local_dir_use_symlinks=False)'
-mv ggml-model-q4_0.bin api/weights/ggml-alpaca-30b-q4.bin
-```
-
-Or you can download the file manually from [here](https://huggingface.co/Pi3141/alpaca-30B-ggml/resolve/main/ggml-model-q4_0.bin) and place it in the `api/weights` folder. No alternatives yet.
-
-### Model conversion
-
-Note: `llama.cpp` [recently underwent some change](https://github.com/ggerganov/llama.cpp/issues/324#issuecomment-1476227818) that requires model weights to be converted to a new format. Serge picks this up automatically on startup, and will convert your weights to the new format if needed. The old weights will be renamed to `*.bin.old` and the new weights will be named `*.bin`.
+If you have existing weights from another project you can add them to the `api/weights` folder and they will be automatically copied on build.
 
 ## What's next
 

--- a/README.md
+++ b/README.md
@@ -20,52 +20,76 @@ cd serge
 
 cp .env.sample .env
 
-curl -o api/weights/ggml-alpaca-7b-q4.bin -C - https://gateway.estuary.tech/gw/ipfs/QmQ1bf2BTnYxq73MFJWu1B7bQ2UD6qG7D7YDCxhTndVkPC
-
-python -c 'from huggingface_hub import hf_hub_download; hf_hub_download(repo_id="decapoda-research/llama-7b-hf", filename="tokenizer.model", local_dir="api/weights/")'
-
 docker compose up -d
+docker compose exec api python3 /usr/src/app/utils/download.py tokenizer 7B 13B
 ```
 
 (You will need `huggingface_hub` for fetching the tokenizer, just run `pip install huggingface_hub` before if you don't have it, no setup needed. Otherwise just [download the file manually](https://huggingface.co/decapoda-research/llama-7b-hf/blob/main/tokenizer.model))
 
 Then just go to http://localhost:8008/ and you're good to go!
 
-### Getting the weights
+## Getting the weights
 
 You will need to download the weights for the model you want to use. Currently we only support 7B and 13B models. Place the downloaded weights in the `api/weights` folder.
 
-#### 7B
+### 7B (~4GB of ram)
 
-For the 7B version use any of these links :
-
-[ggml-alpaca-7b-q4.bin (magnet link)](https://maglit.me/corotlesque)
+Recommmended way is from huggingface. One-liner:
 
 ```
+python -c 'from huggingface_hub import hf_hub_download; hf_hub_download(repo_id="Pi3141/alpaca-7B-ggml", filename="ggml-model-q4_0.bin", local_dir=".", local_dir_use_symlinks=False)'
+mv ggml-model-q4_0.bin api/weights/ggml-alpaca-7b-q4.bin
+```
+
+Or you can download the file manually from [here](https://huggingface.co/Pi3141/alpaca-7B-ggml/resolve/main/ggml-model-q4_0.bin) and place it in the `api/weights` folder.
+
+Alternatives :
+
+```
+# torrent
+magnet:?xt=urn:btih:053b3d54d2e77ff020ebddf51dad681f2a651071&dn=ggml-alpaca-13b-q4.bin&tr=udp%3a%2f%2ftracker.opentrackr.org%3a1337%2fannounce&tr=udp%3a%2f%2fopentracker.i2p.rocks%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.openbittorrent.com%3a6969%2fannounce&tr=udp%3a%2f%2f9.rarbg.com%3a2810%2fannounce
+
 # or any of these should work
 curl -o ggml-alpaca-7b-q4.bin -C - https://gateway.estuary.tech/gw/ipfs/QmQ1bf2BTnYxq73MFJWu1B7bQ2UD6qG7D7YDCxhTndVkPC
 curl -o ggml-alpaca-7b-q4.bin -C - https://ipfs.io/ipfs/QmQ1bf2BTnYxq73MFJWu1B7bQ2UD6qG7D7YDCxhTndVkPC
 curl -o ggml-alpaca-7b-q4.bin -C - https://cloudflare-ipfs.com/ipfs/QmQ1bf2BTnYxq73MFJWu1B7bQ2UD6qG7D7YDCxhTndVkPC
 ```
 
-#### 13B
+### 13B (~10GB of ram)
 
-For the 13B version (10+GB RAM needed) you can use any of these links :
-
-[ggml-alpaca-13b-q4.bin (magnet link)](https://maglit.me/nonchoodithvness)
+Recommmended way is from huggingface. One-liner:
 
 ```
+python -c 'from huggingface_hub import hf_hub_download; hf_hub_download(repo_id="Pi3141/alpaca-13B-ggml", filename="ggml-model-q4_0.bin", local_dir=".", local_dir_use_symlinks=False)'
+mv ggml-model-q4_0.bin api/weights/ggml-alpaca-13b-q4.bin
+```
+
+Or you can download the file manually from [here](https://huggingface.co/Pi3141/alpaca-13B-ggml/resolve/main/ggml-model-q4_0.bin) and place it in the `api/weights` folder.
+
+Alternatives:
+
+```
+# torrent
+magnet:?xt=urn:btih:053b3d54d2e77ff020ebddf51dad681f2a651071&dn=ggml-alpaca-13b-q4.bin&tr=udp%3a%2f%2ftracker.opentrackr.org%3a1337%2fannounce&tr=udp%3a%2f%2fopentracker.i2p.rocks%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.openbittorrent.com%3a6969%2fannounce&tr=udp%3a%2f%2f9.rarbg.com%3a2810%2fannounce
+
 # or any of these should work
 curl -o ggml-alpaca-13b-q4.bin -C - https://gateway.estuary.tech/gw/ipfs/Qme6wyw9MzqbrUMpFNVq42rC1kSdko7MGT9CL7o1u9Cv9G
 curl -o ggml-alpaca-13b-q4.bin -C - https://ipfs.io/ipfs/Qme6wyw9MzqbrUMpFNVq42rC1kSdko7MGT9CL7o1u9Cv9G
 curl -o ggml-alpaca-13b-q4.bin -C - https://cloudflare-ipfs.com/ipfs/Qme6wyw9MzqbrUMpFNVq42rC1kSdko7MGT9CL7o1u9Cv9G
 ```
 
-#### Other models
+### 30B ~(30GB of ram)
 
-If you want to run it with the original LLaMa weights you will have to provide the weights yourself, as they are not available publicly.
+Recommmended way is from huggingface. One-liner:
 
-#### Model conversion
+```
+python -c 'from huggingface_hub import hf_hub_download; hf_hub_download(repo_id="Pi3141/alpaca-30B-ggml", filename="ggml-model-q4_0.bin", local_dir=".", local_dir_use_symlinks=False)'
+mv ggml-model-q4_0.bin api/weights/ggml-alpaca-30b-q4.bin
+```
+
+Or you can download the file manually from [here](https://huggingface.co/Pi3141/alpaca-30B-ggml/resolve/main/ggml-model-q4_0.bin) and place it in the `api/weights` folder. No alternatives yet.
+
+### Model conversion
 
 Note: `llama.cpp` [recently underwent some change](https://github.com/ggerganov/llama.cpp/issues/324#issuecomment-1476227818) that requires model weights to be converted to a new format. Serge picks this up automatically on startup, and will convert your weights to the new format if needed. The old weights will be renamed to `*.bin.old` and the new weights will be named `*.bin`.
 

--- a/api/Dockerfile.api
+++ b/api/Dockerfile.api
@@ -14,7 +14,6 @@ WORKDIR /tmp
 RUN git clone https://github.com/ggerganov/llama.cpp.git --branch master-d5850c5
 
 RUN cd llama.cpp && \
-    sed -i 's/{ 5120, 2 },/{ 5120, 1 },/g' llama.cpp && \
     make && \
     mv main llama
 

--- a/api/main.py
+++ b/api/main.py
@@ -60,30 +60,6 @@ def list_of_installed_models():
     return files
 
 
-@app.post("/generate_raw", tags=["misc."])
-async def generate_text_without_prompt_manipulation(
-    prompt: str,
-    temp: float = 0.8,
-    top_k: int = 40,
-    top_p: float = 0.9,
-    repeast_last_n: int = 64,
-    repeat_penalty: float = 1.3,
-    model: str = "ggml-alpaca-13b-q4.bin",
-):
-
-    answer = await generate(
-        prompt=prompt,
-        temp=temp,
-        top_k=top_k,
-        top_p=top_p,
-        repeast_last_n=repeast_last_n,
-        repeat_penalty=repeat_penalty,
-        model=model,
-    )
-
-    return {"question": prompt, "answer": answer[len(answer) :]}
-
-
 @app.post("/chat", tags=["chats"])
 async def create_new_chat(
     model: str = "ggml-alpaca-13b-q4.bin",

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -6,3 +6,4 @@ pymongo
 beanie
 pydantic[dotenv]
 sentencepiece
+huggingface_hub

--- a/api/utils/convert.py
+++ b/api/utils/convert.py
@@ -96,10 +96,14 @@ def convert_one_file(path_in, tokenizer):
             copy_all_data(f_out, f_in)
     except Exception:
         print(f"File {path_in} already converted")
-        os.remove(path_tmp)
     else:
         os.rename(path_in, path_in + ".old")
         os.rename(path_tmp, path_in)
+
+    try:
+        os.remove(path_tmp)
+    except OSError:
+        pass
 
 
 def convert_all(dir_model: str, tokenizer_model: str):
@@ -107,7 +111,15 @@ def convert_all(dir_model: str, tokenizer_model: str):
     files.extend(glob.glob(f"{dir_model}/*.bin"))
     files.extend(glob.glob(f"{dir_model}/*.bin"))
 
-    tokenizer = SentencePieceProcessor(tokenizer_model)
+    try:
+        tokenizer = SentencePieceProcessor(tokenizer_model)
+    except OSError:
+        print("Missing tokenizer, don't forget to download it!")
 
     for file in files:
         convert_one_file(file, tokenizer)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    convert_all(args.dir_model, args.tokenizer_model)

--- a/api/utils/download.py
+++ b/api/utils/download.py
@@ -1,0 +1,56 @@
+import argparse
+import huggingface_hub
+import os
+
+from typing import List
+from convert import convert_all
+
+models_info = {
+    "7B": ["Pi3141/alpaca-7B-ggml", "ggml-model-q4_0.bin"],
+    "13B": ["Pi3141/alpaca-13B-ggml", "ggml-model-q4_0.bin"],
+    "30B": ["Pi3141/alpaca-30B-ggml", "ggml-model-q4_0.bin"],
+    "tokenizer": ["decapoda-research/llama-7b-hf", "tokenizer.model"],
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Download and convert LLaMA models to the current format"
+    )
+    parser.add_argument(
+        "model",
+        help="Model name",
+        nargs="+",
+        choices=["7B", "13B", "30B", "tokenizer"],
+    )
+
+    return parser.parse_args()
+
+
+def download_models(models: List[str]):
+    for model in models:
+        repo_id, filename = models_info[model]
+        print(f"Downloading {model} model from {repo_id}...")
+
+        huggingface_hub.hf_hub_download(
+            repo_id=repo_id,
+            filename=filename,
+            local_dir="weights",
+            local_dir_use_symlinks=False,
+            cache_dir="weights/.cache",
+        )
+
+        if filename == "ggml-model-q4_0.bin":
+            os.rename(
+                "weights/ggml-model-q4_0.bin", f"weights/ggml-alpaca-{model}-q4_0.bin"
+            )
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    print("Downloading models from HuggingFace")
+    download_models(args.model)
+
+    print("Converting models to the current format")
+    convert_all("weights", "weights/tokenizer.model")

--- a/api/utils/generate.py
+++ b/api/utils/generate.py
@@ -44,6 +44,8 @@ async def generate(
         str(repeat_penalty),
         "--threads",
         "4",
+        "--n_parts",
+        "1",
     )
 
     procLlama = await asyncio.create_subprocess_exec(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       dockerfile: ./Dockerfile.api
     volumes:
       - ./api:/usr/src/app/
+      - /usr/src/app/weights/
       - /etc/localtime:/etc/localtime:ro 
     depends_on:
       - mongodb


### PR DESCRIPTION
This PR ads an autodownload script that fetches the model weights from huggingface. This simplifies the initial setup of Serge to just :

```
git clone git@github.com:nsarrazin/serge.git && cd serge

cp .env.sample .env

docker compose up -d
docker compose exec api python3 /usr/src/app/utils/download.py tokenizer 7B
```

This also adds support for the 30B theoretically, although I haven't tried it.

This PR closes #2, #13