### PR TITLE
do not block server while initializing models

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,4 +1,4 @@
-fastapi[all]
+fastapi[all]>=0.95.0
 sse-starlette
 asyncio
 motor


### PR DESCRIPTION
Fixes #12 

If endpoints requiring models are called before the initialization is done, a 503 error is returned

Note that additional checks could be added to `dep_models_ready()` to ensure the bin file and weight are present
