### PR TITLE
Move the weights to their own volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: ./Dockerfile.api
     volumes:
       - ./api:/usr/src/app/
-      - /usr/src/app/weights/
+      - weights:/usr/src/app/weights/
       - /etc/localtime:/etc/localtime:ro 
     depends_on:
       - mongodb
@@ -41,3 +41,4 @@ services:
 
 volumes:
   data:
+  weights:


### PR DESCRIPTION
This was needed to persist the weights when bringing the container down. Now any downloaded model gets persisted when the container is brought down & back up.

You can still delete the volume individually if you want that. Or bring everything down and erase chats & weights with `docker compose down -v`