### PR TITLE
Let the API run as a standalone behind NGINX without webapp

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - /etc/localtime:/etc/localtime:ro 
     depends_on:
       - mongodb
+      - nginx
     env_file:
       - .env
     command: uvicorn main:app --reload --host 0.0.0.0 --port 9124 --root-path /api/
@@ -32,6 +33,9 @@ services:
       - ./web:/usr/src/app/
       - /usr/src/app/node_modules
     command: npm run dev -- --host 0.0.0.0 --port 9123
+    depends_on:
+      - nginx
+      - api
   nginx:
     build: 
       context: ./nginx

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,9 +1,15 @@
 server {
     listen 80; # Adjust the port number if needed
     server_name localhost;
+
+    resolver 127.0.0.11;
+
+    set $api api:9124;
+    set $web web:9123;
+
     # Proxy requests for the root URL to Service A
     location / {
-        proxy_pass http://web:9123;
+        proxy_pass http://$web;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -16,12 +22,11 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
-
     }
 
     # Proxy requests for /api to Service B
     location /api/ {
-        proxy_pass http://api:9124;
+        proxy_pass http://$api;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This was requested by a few people and would help with future integrations. 

You can now bring up just the API server with 
```
docker compose up -d api
```
 and it will be accessible as usual, for example http://localhost:8008/api/docs


Fixes #7 