### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ A chat interface based on `llama.cpp` for running Alpaca models. Entirely self-h
 
 Setting up Serge is very easy. TLDR for running it with Alpaca 7B:
 
+Install [Docker Desktop](https://www.docker.com/products/docker-desktop/), if you haven't already.
+
 ```
 git clone https://github.com/nsarrazin/serge.git && cd serge
 


### PR DESCRIPTION
The tl;dr instructions assume the use of Docker Desktop, rather than the docker command line tools installed some other way (eg. homebrew on macOS) which often has slightly different syntax. This patch adds a line before the tl;dr instructions to indicate Docker Desktop is required.