### PR TITLE
Update Dockerfile to enable llama build on M1 mac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcc:12 as llama_builder 
+FROM gcc:11 as llama_builder 
 
 WORKDIR /tmp
 


### PR DESCRIPTION
gcc12 doesn't work when running make on M1 mac