### PR TITLE
Use llama precompiled source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM ghcr.io/ggerganov/llama.cpp:light-19726169b379bebc96189673a19b89ab1d307659 as llama_builder 
 
-RUN mv main llama
 
 # Copy over rest of the project files
 
@@ -35,7 +34,7 @@ COPY ./api/requirements.txt api/requirements.txt
 RUN pip install -r ./api/requirements.txt
 
 # copy llama binary from llama_builder
-COPY --from=llama_builder /llama /usr/bin/llama
+COPY --from=llama_builder /main /usr/bin/llama
 
 # copy built webserver from web_builder
 COPY ./web/package.json web/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ggerganov/llama.cpp:light-19726169b379bebc96189673a19b89ab1d307659 as llama_builder 
+FROM ghcr.io/ggerganov/llama.cpp:light-34c1072e497eb92d81ee7c0e12aa6741496a41c6 as llama_builder 
 
 
 # Copy over rest of the project files

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
-FROM gcc:11 as llama_builder 
+FROM ghcr.io/ggerganov/llama.cpp:light as llama_builder 
 
-WORKDIR /tmp
-
-RUN git clone https://github.com/ggerganov/llama.cpp.git --branch master-d5850c5
-
-RUN cd llama.cpp && \
-    make && \
-    mv main llama
+RUN mv main llama
 
 # Copy over rest of the project files
 
@@ -41,7 +35,7 @@ COPY ./api/requirements.txt api/requirements.txt
 RUN pip install -r ./api/requirements.txt
 
 # copy llama binary from llama_builder
-COPY --from=llama_builder /tmp/llama.cpp/llama /usr/bin/llama
+COPY --from=llama_builder /llama /usr/bin/llama
 
 # copy built webserver from web_builder
 COPY ./web/package.json web/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ggerganov/llama.cpp:light as llama_builder 
+FROM ghcr.io/ggerganov/llama.cpp:light-19726169b379bebc96189673a19b89ab1d307659 as llama_builder 
 
 RUN mv main llama
 

--- a/api/Dockerfile.api
+++ b/api/Dockerfile.api
@@ -1,12 +1,6 @@
-FROM gcc:10.2 as builder 
+FROM ghcr.io/ggerganov/llama.cpp:light as builder 
 
-WORKDIR /tmp
-
-RUN git clone https://github.com/ggerganov/llama.cpp.git --branch master-d5850c5
-
-RUN cd llama.cpp && \
-    make && \
-    mv main llama
+RUN mv main llama
 
 FROM ubuntu:latest
 WORKDIR /usr/src/app
@@ -18,4 +12,4 @@ RUN pip install --upgrade pip
 COPY ./requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
-COPY --from=builder /tmp/llama.cpp/llama /usr/bin/llama
+COPY --from=builder /llama /usr/bin/llama

--- a/api/Dockerfile.api
+++ b/api/Dockerfile.api
@@ -1,6 +1,12 @@
-FROM ghcr.io/ggerganov/llama.cpp:light as builder 
+FROM gcc:10.2 as builder 
 
-RUN mv main llama
+WORKDIR /tmp
+
+RUN git clone https://github.com/ggerganov/llama.cpp.git --branch master-d5850c5
+
+RUN cd llama.cpp && \
+    make && \
+    mv main llama
 
 FROM ubuntu:latest
 WORKDIR /usr/src/app
@@ -12,4 +18,4 @@ RUN pip install --upgrade pip
 COPY ./requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
-COPY --from=builder /llama /usr/bin/llama
+COPY --from=builder /tmp/llama.cpp/llama /usr/bin/llama


### PR DESCRIPTION
### Description
This change just modifies the Docker build for the API to use the precompiled llama Docker image as opposed to compiling from source every build. 

### Changes
- Alter API Docker build to remove the need to compile llama from source

### Issue
https://github.com/nsarrazin/serge/issues/48