### PR TITLE
Improvements to github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -41,7 +41,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2 
         with:
-          username: ${{ github.actor }}
+          username: nsarrazin
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Publish Docker Image

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,53 +1,56 @@
 name: Create and publish a Docker image
 
 on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+  workflow_dispatch:
   release:
-    types: [published]
-
-env:
-  REGISTRY: ghcr.io
-  OWNER: ${{ github.repository.owner }}
+    types: [published, edited]
 
 jobs:
-  build-and-push-image:
+  build-and-publish-image:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - dockerfile: ./Dockerfile
-            image: serge
-            context: .
-    permissions:
-      contents: read
-      packages: write
-
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
         with:
-          registry: ${{ env.REGISTRY }}
+          images: |
+            ghcr.io/nsarrazin/serge
+          tags: |
+            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2 
+        with:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.event.repository.owner.name }}/${{ matrix.image }}
-
       - name: Build and Publish Docker Image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v4
         with:
-          file: ${{ matrix.dockerfile }}
-          context: ${{ matrix.context }}
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:release
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:${{ github.event.release.tag_name }}
-
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      


### PR DESCRIPTION
Changes:
- Added support for building both `linux/amd64` and `linux/arm64`
- Added support for creating Docker tags for: main, latest and semver major and minor versions.
- Support for running Docker Build for each PR.
- Support for dependabot to upgrade github-actions. In the future Docker, npm and pypi can be added.
- Added the cache changes from #70 

Good to know:
- Changes to `main` will update the Docker tags: `main` and `latest`.
- New releases will create Docker images for semver and `latest` tag.
- All PR's will trigger the CI, but will not publish new images.

Next Steps:
- Delete the `release` branch.