### PR TITLE
Move the llama.cpp compilation step to after the image is built

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,3 @@
-# Compile llama
-FROM gcc:11 as llama_builder
-
-WORKDIR /tmp
-
-RUN git clone https://github.com/ggerganov/llama.cpp.git --branch master-d5850c5
-
-RUN cd llama.cpp && \
-    make && \
-    mv main llama
-
 # Base image for node
 FROM node:19 as node_base
 
@@ -25,7 +14,7 @@ WORKDIR /usr/src/app
 
 # Install MongoDB and necessary tools
 RUN apt update && \
-    apt install -y curl wget gnupg python3-pip && \
+    apt install -y curl wget gnupg python3-pip git && \
     wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc | apt-key add - && \
     echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list && \
     apt-get update && \
@@ -36,8 +25,8 @@ COPY ./api/requirements.txt api/requirements.txt
 RUN pip install --upgrade pip && \
     pip install --no-cache-dir -r ./api/requirements.txt
 
-# Copy files
-COPY --from=llama_builder /tmp/llama.cpp/llama /usr/bin/llama
+COPY compile.sh .
+RUN chmod +x compile.sh
 
 # Dev environment
 FROM base as dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,21 +12,22 @@ ENV TZ=Europe/Amsterdam
 
 WORKDIR /usr/src/app
 
+COPY --chmod=0755 compile.sh .
+
 # Install MongoDB and necessary tools
 RUN apt update && \
     apt install -y curl wget gnupg python3-pip git && \
     wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc | apt-key add - && \
     echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list && \
     apt-get update && \
-    apt-get install -y mongodb-org
+    apt-get install -y mongodb-org && \
+    git clone https://github.com/ggerganov/llama.cpp.git --branch master-d5850c5
+
 
 # copy & install python reqs
 COPY ./api/requirements.txt api/requirements.txt
 RUN pip install --upgrade pip && \
     pip install --no-cache-dir -r ./api/requirements.txt
-
-COPY compile.sh .
-RUN chmod +x compile.sh
 
 # Dev environment
 FROM base as dev
@@ -41,8 +42,7 @@ RUN npm ci
 COPY web /usr/src/app/web
 COPY ./api /usr/src/app/api
 
-COPY dev.sh /usr/src/app/dev.sh
-RUN chmod +x /usr/src/app/dev.sh
+COPY --chmod=0755 dev.sh /usr/src/app/dev.sh
 CMD ./dev.sh
 
 # Build frontend
@@ -64,7 +64,6 @@ WORKDIR /usr/src/app
 COPY --from=frontend_builder /usr/src/app/web/build /usr/src/app/api/static/
 COPY ./api /usr/src/app/api
 
-COPY deploy.sh /usr/src/app/deploy.sh
-RUN chmod +x /usr/src/app/deploy.sh
+COPY --chmod=0755 deploy.sh /usr/src/app/deploy.sh
 
 CMD ./deploy.sh

--- a/compile.sh
+++ b/compile.sh
@@ -2,9 +2,9 @@
 
 if ! command -v llama &> /dev/null
 then
-    cd /usr/src/app
-    git clone https://github.com/ggerganov/llama.cpp.git --branch master-d5850c5
-    cd llama.cpp
+    cd /usr/src/app/llama.cpp
     make 
     mv main /usr/bin/llama
+    cd /usr/src/app
+    rm -rf llama.cpp
 fi

--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if ! command -v llama &> /dev/null
+then
+    cd /usr/src/app
+    git clone https://github.com/ggerganov/llama.cpp.git --branch master-d5850c5
+    cd llama.cpp
+    make 
+    mv main /usr/bin/llama
+fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+./compile.sh
 
 mongod &
 

--- a/dev.sh
+++ b/dev.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+./compile.sh 
 
 mongod &
 


### PR DESCRIPTION
# Problem

Currently compiling llama.cpp has to be done on the user's CPU, that means using github workers is out of the question. More about the issue here: https://github.com/nsarrazin/serge/issues/82

# Solution

So as a workaround, the llama binary is created when the image is started up. This is a bit silly and feels wrong but it should make our released images usable. 