### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt update && \
     echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list && \
     apt-get update && \
     apt-get install -y mongodb-org && \
-    git clone https://github.com/ggerganov/llama.cpp.git --branch master-d5850c5
+    git clone https://github.com/ggerganov/llama.cpp.git --branch master-2a98bc1
 
 RUN pip install --upgrade pip
 


### PR DESCRIPTION
F16C is not supported for some devices commit 2a98bc1 from llama.cpp fixed it.  So updated the git clone from this commit.

https://discord.com/channels/1088427963801948201/1088446964477198406/1090412615362154578