### PR TITLE
Adding a new session button which uses current session settings

### DIFF
--- a/web/src/routes/chat/[id]/+page.svelte
+++ b/web/src/routes/chat/[id]/+page.svelte
@@ -54,6 +54,35 @@
       askQuestion();
     }
   }
+
+  function createSameSession(sessionID) {
+    fetch("/api/chat/" + sessionID)
+      .then((response) => response.json())
+      .then((data) => {
+        const { _id, created, parameters } = data;
+        fetch(
+          `/api/chat/?model=${parameters.model}&temperature=${parameters.temperature}&top_k=${parameters.top_k}&top_p=${parameters.top_p}&max_length=${parameters.max_length}&context_window=${parameters.context_window}&repeat_last_n=${parameters.repeat_last_n}&repeat_penalty=${parameters.repeat_penalty}&init_prompt=${parameters.init_prompt}&n_threads=${parameters.n_threads}`,
+          {
+            method: "POST",
+            headers: {
+              accept: "application/json",
+            },
+          }
+        )
+          .then((response) => response.json())
+          .then((data) => {
+            const newSession = { id: data };
+            window.location.href = "/chat/" + newSession.id;
+          });
+      })
+      .catch((error) => console.error(error));
+  }
+
+  document.addEventListener("keydown", function (event) {
+    if (event.key === "n" && event.altKey) {
+      createSameSession($page.params.id);
+    }
+  });
 </script>
 
 <div
@@ -115,6 +144,15 @@
       on:click|preventDefault={askQuestion}
     >
       Send
+    </button>
+    <button
+      type="button"
+      disabled={isLoading}
+      class="btn btn-primary h-10 w-24 text-lg ml-2 mb-5"
+      class:loading={isLoading}
+      on:click|preventDefault={() => createSameSession($page.params.id)}
+    >
+      New
     </button>
   </div>
 </div>

--- a/web/src/routes/chat/[id]/+page.svelte
+++ b/web/src/routes/chat/[id]/+page.svelte
@@ -89,11 +89,24 @@
   class="max-w-4xl mx-auto h-full max-h-screen relative"
   on:keydown={handleKeyDown}
 >
-  <h1 class="text-4xl font-bold">Chat with {data.props.parameters.model}</h1>
-  <h4 class="text-xl font-semibold mb-10">
-    Started on {startDate.toLocaleString("en-US")}
-  </h4>
-  <div class="overflow-y-auto h-[calc(100vh-12rem)] px-10 mb-11">
+<div class="flex items-center">
+  <h1 class="text-4xl font-bold inline-block mr-2">
+    Chat with {data.props.parameters.model}
+  </h1>
+  <button
+    type="button"
+    disabled={isLoading}
+    class="btn btn-sm mr-2 mt-5 mb-5 inline-block"
+    class:loading={isLoading}
+    on:click|preventDefault={() => createSameSession($page.params.id)}
+  >
+    New
+  </button>
+</div>
+<h4 class="text-xl font-semibold mb-5">
+  Started on {startDate.toLocaleString("en-US")}
+</h4>
+  <div class="overflow-y-auto h-[calc(97vh-12rem)] px-10 mb-11">
     <div class="h-max pb-32">
       {#each questions as question}
         <div class="chat chat-end my-2">
@@ -129,16 +142,8 @@
   <div
     class="items-center w-full px-0 h-0 flex flex-row bg-base-100 justify-center"
   >
-    <button
-      type="button"
-      disabled={isLoading}
-      class="btn btn-primary h-10 w-24 text-lg mr-2 mb-5"
-      class:loading={isLoading}
-      on:click|preventDefault={() => createSameSession($page.params.id)}
-    >
-      New
-    </button>
-    <textarea autofocus
+    <textarea
+      autofocus
       name="question"
       class="textarea textarea-bordered h-10 w-full max-w-xl mb-5 text-lg"
       disabled={isLoading}

--- a/web/src/routes/chat/[id]/+page.svelte
+++ b/web/src/routes/chat/[id]/+page.svelte
@@ -138,7 +138,7 @@
     >
       New
     </button>
-    <textarea
+    <textarea autofocus
       name="question"
       class="textarea textarea-bordered h-10 w-full max-w-xl mb-5 text-lg"
       disabled={isLoading}

--- a/web/src/routes/chat/[id]/+page.svelte
+++ b/web/src/routes/chat/[id]/+page.svelte
@@ -129,6 +129,15 @@
   <div
     class="items-center w-full px-0 h-0 flex flex-row bg-base-100 justify-center"
   >
+    <button
+      type="button"
+      disabled={isLoading}
+      class="btn btn-primary h-10 w-24 text-lg mr-2 mb-5"
+      class:loading={isLoading}
+      on:click|preventDefault={() => createSameSession($page.params.id)}
+    >
+      New
+    </button>
     <textarea
       name="question"
       class="textarea textarea-bordered h-10 w-full max-w-xl mb-5 text-lg"
@@ -144,15 +153,6 @@
       on:click|preventDefault={askQuestion}
     >
       Send
-    </button>
-    <button
-      type="button"
-      disabled={isLoading}
-      class="btn btn-primary h-10 w-24 text-lg ml-2 mb-5"
-      class:loading={isLoading}
-      on:click|preventDefault={() => createSameSession($page.params.id)}
-    >
-      New
     </button>
   </div>
 </div>


### PR DESCRIPTION
Made to address #135 

This allows for a "New" button which takes all of the current sessions parameters and creates a new session. 

When the new session is provided by the API we then redirect to the new session ID. 

To make things easy on users, a new hotkey was set up to allow for the use of ALT+N which will create a new session on demand.