### PR TITLE
Expand dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,18 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/api"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/web"
     schedule:
       interval: "daily"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,6 +8,7 @@ on:
       - '**.md'
       - 'docker-compose.yml'
       - 'docker-compose.dev.yml'
+      - '.github/dependabot.yml'
   pull_request:
     branches:
       - 'main'
@@ -15,6 +16,7 @@ on:
       - '**.md'
       - 'docker-compose.yml'
       - 'docker-compose.dev.yml'
+      - '.github/dependabot.yml'
   workflow_dispatch:
   release:
     types: [published, edited]


### PR DESCRIPTION
- Adds support for tracking `npm`, `pip`, and `docker` dependencies.