### PR TITLE
Fixed name of the temperature parameter

### DIFF
--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -83,9 +83,9 @@
           class="tooltip col-span-2"
           data-tip="The higher the temperature, the more random the model output."
         >
-          <label for="temp" class="label-text">Temperature - [{temp}]</label>
+          <label for="temperature" class="label-text">Temperature - [{temp}]</label>
           <input
-            name="temp"
+            name="temperature"
             type="range"
             bind:value={temp}
             min="0.05"


### PR DESCRIPTION
The name of the parameter is `temperature` in the API, but this form passes it as `temp`, so all invocations of `llama` always use a temperature of 0.1 (the default value in the API) regardless of this setting.