### PR TITLE
Pin llama-cpp-python to 0.1.49

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-pip install llama-cpp-python
+pip install llama-cpp-python==0.1.49
 
 redis-server /etc/redis/redis.conf &
 # Start the API


### PR DESCRIPTION
- Lets pin llama-cpp-python to 0.1.49 until models are migrated to the new format