### PR TITLE
update names of vicuna models, fixes #295

### DIFF
--- a/api/src/serge/routers/model.py
+++ b/api/src/serge/routers/model.py
@@ -52,12 +52,12 @@ models_info = {
     ],
     "Vicuna-7B" : [
         "eachadea/ggml-vicuna-7b-1.1",
-        "ggml-vic7b-q4_1.bin",
+        "ggml-old-vic7b-q4_1.bin",
         5.04E9,
     ],
     "Vicuna-13B" : [
         "eachadea/ggml-vicuna-13b-1.1",
-        "ggml-vic13b-q4_2.bin",
+        "ggml-old-vic13b-q4_2.bin",  
         8.13E9,
     ]
 


### PR DESCRIPTION
Fixes issue #295. 

I tested the updated files. They both download and run with the current version of serge/llama used by serge.