### PR TITLE
Don't update latest tag when merging to default brancv

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -36,9 +36,7 @@ jobs:
           images: |
             ghcr.io/nsarrazin/serge
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -37,6 +37,7 @@ jobs:
             ghcr.io/nsarrazin/serge
           tags: |
             type=ref,event=branch
+            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
- Only updates the latest tag when a new release is created 

This will allow testing merges to the main branch