### PR TITLE
Make sure answer is a string when returning to API Client

### DIFF
--- a/api/src/serge/routers/chat.py
+++ b/api/src/serge/routers/chat.py
@@ -246,5 +246,8 @@ async def ask_a_question(chat_id: str, prompt: str):
         history.append(SystemMessage(content=error))
         return error
 
+    if not isinstance(answer, str):
+        answer = str(answer)
+
     history.add_ai_message(answer)
     return answer


### PR DESCRIPTION
The answer coming back fron `llama` can be anything, enforce a String when returning to API Client

Fixes #259